### PR TITLE
spec: define efi_esp_dir macro and mock build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - VERBOSE=0
 import:
   - source: QubesOS/qubes-continuous-integration:R4.1/travis-base-r4.1.yml
   - source: QubesOS/qubes-continuous-integration:R4.1/travis-dom0-r4.1.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,3 @@
-sudo: required
-dist: bionic
-language: generic
-install: git clone https://github.com/QubesOS/qubes-builder ~/qubes-builder
-script: ~/qubes-builder/scripts/travis-build
-env:
- - DIST_DOM0=fc31 USE_QUBES_REPO_VERSION=4.1 USE_QUBES_REPO_TESTING=1 VERBOSE=0
-
-# don't build tags which are meant for code signing only
-branches:
-  except:
-    - /.*_.*/
-    - build
+import:
+  - source: QubesOS/qubes-continuous-integration:R4.1/travis-base-r4.1.yml
+  - source: QubesOS/qubes-continuous-integration:R4.1/travis-dom0-r4.1.yml

--- a/grub2.spec
+++ b/grub2.spec
@@ -879,8 +879,8 @@ rm -r /boot/grub2.tmp/ || :
 %files common -f grub.lang
 %dir %{_libdir}/grub/
 %dir %{_datarootdir}/grub/
-%dir %{_datarootdir}/grub/themes/
-%exclude %{_datarootdir}/grub/themes/*
+#%dir %{_datarootdir}/grub/themes/
+#%exclude %{_datarootdir}/grub/themes/*
 %attr(0700,root,root) %dir %{_sysconfdir}/grub.d
 %{_prefix}/lib/kernel/install.d/20-grub.install
 %{_prefix}/lib/kernel/install.d/99-grub-mkconfig.install
@@ -889,7 +889,7 @@ rm -r /boot/grub2.tmp/ || :
 %dir /boot/%{name}
 %dir /boot/%{name}/themes/
 %dir /boot/%{name}/themes/system
-%exclude /boot/%{name}/themes/system/*
+#%exclude /boot/%{name}/themes/system/*
 %attr(0700,root,root) %dir /boot/grub2
 %exclude /boot/grub2/*
 %dir %attr(0700,root,root) %{efi_esp_dir}

--- a/grub2.spec
+++ b/grub2.spec
@@ -5,6 +5,7 @@
 %global _configure_gnuconfig_hack 0
 
 %global efi_vendor qubes
+%global efi_esp_dir /boot/efi/EFI/%{efi_vendor}
 
 ### begin grub.macros
 # vim:filetype=spec


### PR DESCRIPTION
It fixes missing unicode.pf2 file at grub boot because default value
for efi_esp_dir is /boot/efi/EFI/fedora