### PR TITLE
Switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell cat version)
+VERSION := $(file <version)
 
 SRC_FILE := grub-$(VERSION).tar.xz
 SIGN_FILE := $(SRC_FILE).sig
@@ -15,10 +15,10 @@ endif
 get-sources: $(SRC_FILE) $(SIGN_FILE)
 
 $(SRC_FILE):
-	@$(FETCH_CMD) $(SRC_FILE) $(URL_FILE)
+	@$(FETCH_CMD) $(SRC_FILE) $(URL_FILE) || { echo "Curl failed with code $$?"; exit 1; }
 
 $(SIGN_FILE):
-	@$(FETCH_CMD) $(SIGN_FILE) $(URL_SIGN)
+	@$(FETCH_CMD) $(SIGN_FILE) $(URL_SIGN) || { echo "Curl failed with code $$?"; exit 1; }
 
 import-keys:
 	@if [ -n "$$GNUPGHOME" ]; then rm -f "$$GNUPGHOME/linux-pvgrub2-trustedkeys.gpg"; fi

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,17 @@ URL := https://ftp.gnu.org/gnu/grub/
 URL_FILE := $(URL)$(SRC_FILE)
 URL_SIGN := $(URL)$(SIGN_FILE)
 
+ifeq ($(FETCH_CMD),)
+$(error "You can not run this Makefile without having FETCH_CMD defined")
+endif
+
 get-sources: $(SRC_FILE) $(SIGN_FILE)
 
 $(SRC_FILE):
-	@wget -q -N $(URL_FILE)
+	@$(FETCH_CMD) $(SRC_FILE) $(URL_FILE)
 
 $(SIGN_FILE):
-	@wget -q -N $(URL_SIGN)
+	@$(FETCH_CMD) $(SIGN_FILE) $(URL_SIGN)
 
 import-keys:
 	@if [ -n "$$GNUPGHOME" ]; then rm -f "$$GNUPGHOME/linux-pvgrub2-trustedkeys.gpg"; fi


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.