### PR TITLE
Fix grub-efi-x64-cdboot package

### DIFF
--- a/grub2.spec.in
+++ b/grub2.spec.in
@@ -225,7 +225,7 @@ Source13:	99-grub-mkconfig.install
 %ifarch %{efi_arch}
 %global with_efi_arch 1
 %global grubefiname grub%{efiarch}.efi
-%global grubeficdname gcd%{efiarch}.efi
+%global grubeficdname boot%{efiarch}.efi
 %global grubefiarch %{target_cpu_name}-efi
 %ifarch %{ix86}
 %global with_efi_modules 0


### PR DESCRIPTION
The fallback EFI location (/EFI/BOOT/BOOTX64.efi) is useful on removable
media. Fedora's use shim in that location, but Qubes doesn't - lets put
grub directly there, to ease using Qubes installed on removable disks.

Fixes QubesOS/qubes-issues#8363