### PR TITLE
Fix grub.cfg conversion

### DIFF
--- a/grub2.spec.in
+++ b/grub2.spec.in
@@ -1215,7 +1215,9 @@ if test -f ${EFI_HOME}/grubenv; then
 fi
 
 cp -a ${EFI_HOME}/grub.cfg ${EFI_HOME}/grub.cfg.rpmsave
-cp -a ${EFI_HOME}/grub.cfg ${GRUB_HOME}/
+if test ! -f ${GRUB_HOME}/grub.cfg; then
+    cp -a ${EFI_HOME}/grub.cfg ${GRUB_HOME}/
+fi
 mv ${EFI_HOME}/grub.cfg.stb ${EFI_HOME}/grub.cfg
 
 %files common -f grub.lang


### PR DESCRIPTION
The current package creates updated stub grub.cfg in the EFI partition
with the extra --root-dev-only option. It also tries to update it, if
the old version was there. But, while doing so, it mistakenly copied old
stub over the proper /boot/grub2/grub.cfg, causing infinite grub.cfg
loading loop. Fix it by not overriding /boot/grub2/grub.cfg if it's
already there.

Fixes: fb08091 "Add patches preventing using wrong config in case of duplicate UUID"

QubesOS/qubes-issues#9317