### PR TITLE
grub2-efi: add font file

### DIFF
--- a/grub2.spec.in
+++ b/grub2.spec.in
@@ -688,7 +688,7 @@ ln -s ../boot/grub2/grub.cfg					\\\
 %ifarch %{arm}							\
 %attr(0700,root,root)%{efi_esp_boot}/BOOTARM.EFI		\
 %endif								\
-%dir %attr(0700,root,root)%{efi_esp_dir}/fonts			\
+%attr(0700,root,root)%{efi_esp_dir}/fonts			\
 %dir %attr(0700,root,root)/boot/loader/entries			\
 %ghost %config(noreplace) /boot/grub2/grub.cfg		\
 %ghost %config(noreplace) %attr(0700,root,root)%{efi_esp_dir}/grub.cfg	\


### PR DESCRIPTION
Currently grub2-efi-cdboot package has font file,
but grub2-efi package's fonts folder is empty.
This caused by wrong %files section.

Upstream bugzilla: rhbz#1739762
Upstream commit: 9cf30d9

Upstream moves fonts folder to /boot/grub2,
but I think fonts folder inside ESP also works.
(See people's comments at rhbz)

Separate font file will not work after
enabling Secure Boot, but Qubes doesn't support SB.

QubesOS/qubes-issues#8335