### PR TITLE
rpm: create empty main package to fix debuginfo deps

### DIFF
--- a/grub2.spec.in
+++ b/grub2.spec.in
@@ -1220,6 +1220,8 @@ if test ! -f ${GRUB_HOME}/grub.cfg; then
 fi
 mv ${EFI_HOME}/grub.cfg.stb ${EFI_HOME}/grub.cfg
 
+%files
+
 %files common -f grub.lang
 %dir %{_libdir}/grub/
 %dir %{_datarootdir}/grub/


### PR DESCRIPTION
Fedora's debuginfo automagic depends on main package being
present - it adds dependency on %{name}-debuginfo to all debuginfo
subpackages.
Create the empty main package to make it work.
